### PR TITLE
Add support for AppStream kickstart repos [RHELDST-14528]

### DIFF
--- a/repo_autoindex/_impl/kickstart.py
+++ b/repo_autoindex/_impl/kickstart.py
@@ -132,15 +132,15 @@ class KickstartRepo(YumRepo):
 
         treeinfo = configparser.ConfigParser()
         treeinfo.read_string(self.treeinfo_content)
-
-        for image in treeinfo["checksums"]:
-            entry = IndexEntry(
-                href=image,
-                text=os.path.basename(image),
-            )
-            if entry.href.endswith(".iso") or entry.href.endswith(".img"):
-                entry.icon = ICON_OPTICAL
-            out.append(entry)
+        if "checksums" in treeinfo:
+            for image in treeinfo["checksums"]:
+                entry = IndexEntry(
+                    href=image,
+                    text=os.path.basename(image),
+                )
+                if entry.href.endswith(".iso") or entry.href.endswith(".img"):
+                    entry.icon = ICON_OPTICAL
+                out.append(entry)
         return out
 
     async def _extra_files_entries(self) -> list[IndexEntry]:


### PR DESCRIPTION
AppStream kickstart repos were missing from the initial collection of repos used to test the kickstart repo index functionality. AppStream repos uniquely do not contain "checksums" sections in their treeinfo files. So, when attempting to run repo-autoindex against an AppStream kickstart repo, "KeyError: 'checksums'" was raised.

Now, when encountering an AppStream kickstart repo, repo-autoindex does not attempt to parse the "checksums" section.