### PR TITLE
Add py.typed for PEP 561

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ information about the usage of `repo-autoindex`.
 
 ## Changelog
 
+### v1.1.2 - 2023-09-18
+
+- Add `py.typed` to make package PEP 561 compliant / enable downstream type-checking.
+
 ### v1.1.1 - 2023-04-12
 
 - Fix handling of kickstart repositories with no checksums in treeinfo.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = "repo-autoindex"
 copyright = "2023, Red Hat"
 author = "Rohan McGovern <rmcgover@redhat.com>"
-release = "1.1.1"
+release = "1.1.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "repo-autoindex"
-version = "1.1.1"
+version = "1.1.2"
 description = "Generic static HTML indexes of various repository types"
 authors = ["Rohan McGovern <rmcgover@redhat.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
This library includes inline type hints, but per PEP 561 this must be indicated by including a "py.typed" marker file, otherwise tools like mypy will not make use of the type hints when checking downstream projects.