### PR TITLE
[ci] fix install of OS packages in CI workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,8 +15,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install system dependencies
-        run: sudo apt-get install -y libkrb5-dev
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y libkrb5-dev
       - name: Install Tox
         run: pip install tox
       - name: Run Tox


### PR DESCRIPTION
We should be using "apt-get update" to update package lists before installing any new packages. This has never mattered before, but recently the installation of various packages started to fail with 404 errors, which are resolved by updating the package lists first.