### PR TITLE
Fix tests for aiohttp 3.10

### DIFF
--- a/repo_autoindex/_impl/api.py
+++ b/repo_autoindex/_impl/api.py
@@ -40,6 +40,7 @@ def http_fetcher(session: aiohttp.ClientSession) -> Fetcher:
             # Deal with the non-ideal content negotiation
             # for certain storage backends.
             if url.endswith(".gz") and resp.content_type in (
+                "application/gzip",
                 "application/x-gzip",
                 "application/octet-stream",
             ):


### PR DESCRIPTION
aiohttp 3.10 changed the server's handling of content-type/encoding headers for compressed files. This affects our usage of aiohttp.test_utils.TestServer: gzip-compressed files are no longer being decompressed by default. This in itself is not a problem, but the MIME type used ("application/gzip") did not match our client's list of automatically handled MIME types.

Add it to the list to handle it in the same way as others. This fixes test_cmd::yum with aiohttp=>3.10.