### PR TITLE
Add --cov option for cov testenv [RHELDST-40410]

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,4 +35,4 @@ deps = poetry
 skip_install = True
 commands =
     poetry install -v
-    poetry run py.test -v --cov-report html --cov-report xml {posargs}
+    poetry run py.test -v --cov repo_autoindex --cov-report html --cov-report xml {posargs}


### PR DESCRIPTION
Adds the --cov option for the cov testenv to ensure coverage.xml is created